### PR TITLE
Update oxium in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7263,7 +7263,7 @@
       "dev": true
     },
     "oxium": {
-      "version": "github:hobroker/oxium#c9c83ff91b27de2d2ded2e56e33a720e1a9e5b58",
+      "version": "github:hobroker/oxium#b405af14b00e7a76cdb2a5ab24f70ed037333397",
       "from": "github:hobroker/oxium",
       "requires": {
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7263,8 +7263,8 @@
       "dev": true
     },
     "oxium": {
-      "version": "github:hobroker/oxium#b405af14b00e7a76cdb2a5ab24f70ed037333397",
-      "from": "github:hobroker/oxium",
+      "version": "github:hobroker/oxium#8cf741a4fc76134c82225429fced52ed80a86e60",
+      "from": "github:hobroker/oxium#v0.1.0",
       "requires": {
         "debug": "^4.1.1",
         "esm": "^3.2.25",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "monet": "^0.9.1",
     "mongoose": "^5.8.11",
     "morgan": "^1.9.1",
-    "oxium": "github:hobroker/oxium",
+    "oxium": "github:hobroker/oxium#v0.1.0",
     "ramda": "^0.27.0",
     "ramda-adjunct": "^2.25.0",
     "spotify-web-api-node": "^4.0.0",


### PR DESCRIPTION
The oxium version hash in `package-lock.json` points to an old version.